### PR TITLE
Make React a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geospatialdraw",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Geospatial Map Drawing Library",
   "types": "bin/index.d.ts",
   "main": "bin/index.js",
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@turf/turf": "5.1.6",
-    "react": "16.9.0",
     "usng.js": "0.4.2"
   },
   "devDependencies": {
@@ -67,6 +66,7 @@
     "ol": "6.0.1",
     "prettier": "1.19.1",
     "prismjs": "1.17.1",
+    "react": "16.9.0",
     "react-dom": "16.9.0",
     "recompose": "0.30.0",
     "rimraf": "3.0.0",
@@ -74,9 +74,8 @@
     "typescript-bundle": "1.0.16"
   },
   "peerDependencies": {
-    "ol": "6.x"
-  },
-  "resolutions": {
-    "react": "16.9.0"
+    "ol": "6.x",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   }
 }


### PR DESCRIPTION
Adds react as a peer dependency instead of straight dependency. This is causing issues downstream because it causes us to have multiple versions of react in the project: https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react