### PR TITLE
Fix panToGeoList not taking into account geo extents without bbox

### DIFF
--- a/lib/renderer/renderer.tsx
+++ b/lib/renderer/renderer.tsx
@@ -86,9 +86,7 @@ class Renderer {
    */
   panToGeoList(geometryList: GeometryJSON[]) {
     if (geometryList.length > 0) {
-      this.panToExtent(
-        combineExtents(geometryList.map(geometry => geometry.bbox))
-      )
+      this.panToExtent(combineExtents(geometryList.map(this.getExtent)))
     }
   }
 


### PR DESCRIPTION
The panToGeoList function only takes into account a geo's bbox. It should mirror panToGeo's method of getting the Extent from a geo.