### PR TITLE
Allow point radius to have buffer of 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geospatialdraw",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Geospatial Map Drawing Library",
   "types": "./target/webapp/index.d.ts",
   "main": "./target/webapp/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geospatialdraw",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "description": "Geospatial Map Drawing Library",
   "types": "./target/webapp/index.d.ts",
   "main": "./target/webapp/index.js",

--- a/src/main/webapp/drawing-controls/point-radius-drawing-control.tsx
+++ b/src/main/webapp/drawing-controls/point-radius-drawing-control.tsx
@@ -40,22 +40,20 @@ class PointRadiusDrawingControl extends BasicDrawingControl {
   }
 
   private startDrawAnimation(feature: ol.Feature) {
-    if (this.properties.buffer) {
-      let revision = feature.getRevision()
-      this.animationFrame = () => {
-        const update = feature.getRevision()
-        if (update !== revision) {
-          revision = update
-          const pointFeature = new ol.Feature(
-            this.updatePointFromRadiusLine(this.toLine(feature))
-          )
-          this.applyPropertiesToFeature(pointFeature)
-          this.context.updateBufferFeature(pointFeature, false)
-        }
-        this.animationFrameId = requestAnimationFrame(this.animationFrame)
+    let revision = feature.getRevision()
+    this.animationFrame = () => {
+      const update = feature.getRevision()
+      if (update !== revision) {
+        revision = update
+        const pointFeature = new ol.Feature(
+          this.updatePointFromRadiusLine(this.toLine(feature))
+        )
+        this.applyPropertiesToFeature(pointFeature)
+        this.context.updateBufferFeature(pointFeature, false)
       }
-      this.animationFrame()
+      this.animationFrameId = requestAnimationFrame(this.animationFrame)
     }
+    this.animationFrame()
   }
 
   private stopDrawAnimation(feature: ol.Feature): GeometryJSON {

--- a/src/main/webapp/geometry/utilities.tsx
+++ b/src/main/webapp/geometry/utilities.tsx
@@ -75,7 +75,7 @@ const makeEmptyGeometry = (
     ...initialProperties,
     shape,
     id,
-    buffer: shape === 'Point Radius' ? Number.MIN_VALUE : 0,
+    buffer: 0,
     bufferUnit: METERS,
   },
   bbox: [0, 0, 0, 0],


### PR DESCRIPTION
Allow buffer for a new point radius to be 0 and allow drawing animation to start when buffer is 0. The point radius and drawing renders fine with these changes, maybe at some point in the past it didn't but it does now. 

Testing:
1. Build and package project by running `yarn install` and then `npm pack`
2. Point downstream project dependency at the tarball created from the previous step. Something like:
    `"geospatialdraw": "file:///<path-to>/geospatialdraw/geospatialdraw-0.4.8.tgz",`
3. In downstream project, run `yarn install --force`
4. Run the downstream project and attempt drawing a new point radius initialized with 0 for its buffer